### PR TITLE
use process.cwd() as the main directory in REPL.

### DIFF
--- a/lib/hotload.js
+++ b/lib/hotload.js
@@ -58,6 +58,14 @@
       ? args
       : [];
     absPath = resolveCalledFilename(path, 2);
+    
+    // basic nodejs REPL support
+    if(typeof require.main === 'undefined') {
+      mainDir = process.cwd();
+    } else {
+      mainDir = PATH.dirname(require.main.filename);
+    }
+
     mainDir = PATH.dirname(require.main.filename);
     relPath = PATH.relative(mainDir, absPath);
     if (require.cache[absPath] == null) {


### PR DESCRIPTION
Specifically, if `require.main` is not defined, the variable `mainDir` will be set to `process.cwd()`.

This will prevent a fatal error, and instead allow a basic level of REPL support.  

There are some limitations that might not be obvious:  changes to the process working directory will not be tracked, and the node-hotload module will sometimes fail silently if one saves a unsyntactic version of the code being watched;  the node-hotload module then requires reloading from cache.
